### PR TITLE
RED-158292 fix checkout from unstable 

### DIFF
--- a/.github/workflows/build-binary-dists.yml
+++ b/.github/workflows/build-binary-dists.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           # Use unstable branch when called via workflow_call (from nightly scheduler)
           # Use current branch when triggered by PR (for testing)
-          ref: ${{ github.event_name == 'workflow_call' && 'unstable' || github.ref }}
+          ref: ${{ github.event_name == 'push' && github.ref || 'unstable' }}
 
       - name: Install build dependencies
         run: |


### PR DESCRIPTION
Fix checkout from unstable as the github event name is schedule during nightly and not workflow_call