### PR TITLE
Add macos 15 and 26 runners for test job

### DIFF
--- a/.github/workflows/build-binary-dists.yml
+++ b/.github/workflows/build-binary-dists.yml
@@ -7,6 +7,12 @@ on:
       - '.github/workflows/build-binary-dists.yml'
       - 'configs/**'
       - 'scripts/**'
+  pull_request:
+    branches: [ unstable ]
+    paths:
+      - '.github/workflows/build-binary-dists.yml'
+      - 'configs/**'
+      - 'scripts/**'
   workflow_call:
 
 permissions:
@@ -29,8 +35,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           # Use unstable branch when called via workflow_call (from nightly scheduler)
-          # Use current branch when triggered by PR (for testing)
-          ref: ${{ github.event_name == 'push' && github.ref || 'unstable' }}
+          ref: ${{ github.event_name == 'workflow_call' && 'unstable' || github.ref }}
 
       - name: Install build dependencies
         run: |
@@ -99,7 +104,11 @@ jobs:
         os_version:
           - macos-14-large  # macOS 14 x86_64
           - macos-14        # macOS 14 arm64
+          - macos-15-large  # macOS 15 x86_64
+          - macos-15        # macOS 15 arm64
+          - macos-26-large  # macOS 26 x86_64
+          - macos-26        # macOS 26 arm64
     uses: ./.github/workflows/test.yml
     with:
-      artifact_name: unsigned-redis-oss-unstable-${{ matrix.os_version == 'macos-14-large' && 'x86_64' || 'arm64' }}.zip
+      artifact_name: unsigned-redis-oss-unstable-${{ contains(matrix.os_version, '-large') && 'x86_64' || 'arm64' }}.zip
       runner: ${{ matrix.os_version }}


### PR DESCRIPTION
Added macos 15 and 26 runners for test job in build-binary-dists workflow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to GitHub Actions workflow configuration, mainly affecting when/where CI runs and how artifacts are selected.
> 
> **Overview**
> Enables the `build-binary-dists` workflow to run on `pull_request` events targeting `unstable`, so changes to build scripts/configs can be validated before merge.
> 
> Expands the `test` job matrix to include macOS 15 and 26 runners (x86_64 and arm64), and updates artifact naming logic to infer architecture via `contains(os_version, '-large')`. The checkout `ref` selection is also adjusted so only `workflow_call` forces the `unstable` branch; otherwise the workflow uses the triggering ref.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 045ec06d094e27e2b4a25f5117cfd7bb4c4bf0c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->