### PR TITLE
Fix build-binary-dist checkout logic

### DIFF
--- a/.github/workflows/build-binary-dists.yml
+++ b/.github/workflows/build-binary-dists.yml
@@ -34,8 +34,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # Use unstable branch when called via workflow_call (from nightly scheduler)
-          ref: ${{ github.event_name == 'workflow_call' && 'unstable' || github.ref }}
+          ref: >-
+            ${{ (github.ref_name == 'unstable'
+            || github.event_name == 'workflow_call'
+            || github.event_name == 'schedule')
+            && 'unstable'
+            || ''
+            }}
 
       - name: Install build dependencies
         run: |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only adjusts GitHub Actions checkout `ref` selection logic, affecting which branch is built but not product code.
> 
> **Overview**
> Updates the `build-binary-dists.yml` workflow to **more consistently check out the `unstable` branch**: it now forces `unstable` when running on the `unstable` branch, via `workflow_call`, or on scheduled runs, and otherwise leaves `ref` unset to use the default checkout behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 548141a23f2c0316916d8c9e1f7897ccfea27821. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->