### PR TITLE
Enable LTO for RediSearch by upgrading to llvm@21 / Rust 1.94

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,9 +7,13 @@ export BUILD_WITH_MODULES=yes
 export MODULE_VERSION=master
 export BUILD_TLS=yes
 export DISABLE_WERRORS=yes
-PATH="$HOMEBREW_PREFIX/opt/llvm@18/bin:$HOMEBREW_PREFIX/opt/make/libexec/gnubin:$HOMEBREW_PREFIX/opt/gnu-sed/libexec/gnubin:$HOMEBREW_PREFIX/opt/coreutils/libexec/gnubin:$PATH" # Override macOS defaults.
-export LDFLAGS="-L$HOMEBREW_PREFIX/opt/llvm@18/lib"
-export CPPFLAGS="-I$HOMEBREW_PREFIX/opt/llvm@18/include"
+# RediSearch builds with LTO by default (redis/redis@2408a15) and its build.sh
+# enforces that clang's major version matches rustc's bundled LLVM. Rust 1.94
+# ships LLVM 21, so use llvm@21 here.
+export LTO=1
+PATH="$HOMEBREW_PREFIX/opt/llvm@21/bin:$HOMEBREW_PREFIX/opt/make/libexec/gnubin:$HOMEBREW_PREFIX/opt/gnu-sed/libexec/gnubin:$HOMEBREW_PREFIX/opt/coreutils/libexec/gnubin:$PATH" # Override macOS defaults.
+export LDFLAGS="-L$HOMEBREW_PREFIX/opt/llvm@21/lib"
+export CPPFLAGS="-I$HOMEBREW_PREFIX/opt/llvm@21/include"
 
 curl -L "https://github.com/redis/redis/archive/refs/heads/unstable.tar.gz" -o redis-unstable.tar.gz
 tar xzf redis-unstable.tar.gz

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -6,7 +6,7 @@ export HOMEBREW_NO_AUTO_UPDATE=1
 brew update
 brew install coreutils
 brew install make
-brew install llvm@18
+brew install llvm@21
 brew install gnu-sed
 brew install automake
 brew install libtool
@@ -28,7 +28,7 @@ hdiutil detach /Volumes/cmake-macos
 sudo "/Applications/CMake.app/Contents/bin/cmake-gui" --install=/usr/local/bin
 cmake --version
 
-RUST_INSTALLER=rust-1.80.1-$(if [ "$(uname -m)" = "arm64" ]; then echo "aarch64"; else echo "x86_64"; fi)-apple-darwin
+RUST_INSTALLER=rust-1.94.0-$(if [ "$(uname -m)" = "arm64" ]; then echo "aarch64"; else echo "x86_64"; fi)-apple-darwin
 echo "Downloading and installing Rust standalone installer: ${RUST_INSTALLER}"
 wget --quiet -O ${RUST_INSTALLER}.tar.xz https://static.rust-lang.org/dist/${RUST_INSTALLER}.tar.xz
 tar -xf ${RUST_INSTALLER}.tar.xz


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Build tooling changes (LLVM/Rust upgrades and enabling LTO) can affect module compilation, binary size/perf, and CI stability, especially on macOS runners with different Homebrew states.
> 
> **Overview**
> Updates the macOS build scripts to support RediSearch’s default LTO requirements by **enabling `LTO=1`** and switching the toolchain from `llvm@18` to `llvm@21` (including updated `PATH`/`LDFLAGS`/`CPPFLAGS`).
> 
> Upgrades the standalone Rust installer used by dependency setup from `1.80.1` to `1.94.0` to match the LLVM version expected by RediSearch’s build checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c641cf4ff1414383d75203b699a228e2765e1a18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->