### PR TITLE
RED-198334 Bump GH Actions off Node 20

### DIFF
--- a/.github/actions/build-binary-package/action.yml
+++ b/.github/actions/build-binary-package/action.yml
@@ -81,7 +81,7 @@ runs:
     run: |
       sh scripts/notarize.sh ${{ steps.sign.outputs.REDIS_BINARY }} com.redis.redis ${{ inputs.MAC_NOTARIZE_USERNAME }} ${{ inputs.MAC_NOTARIZE_PASSWORD }} ${{ inputs.MAC_NOTARIZE_TEAM_ID }}
   - name: Upload Redis Binary artifact
-    uses: actions/upload-artifact@v4
+    uses: actions/upload-artifact@v7
     with:
       path: ./${{ steps.sign.outputs.REDIS_BINARY }}
       name: ${{ steps.sign.outputs.REDIS_BINARY }}

--- a/.github/actions/edit-version-file/action.yml
+++ b/.github/actions/edit-version-file/action.yml
@@ -18,7 +18,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout common functions
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: redis-developer/redis-oss-release-automation
         ref: main
@@ -32,7 +32,7 @@ runs:
 
     - name: Create verified commit
       if: steps.edit-version.outputs.changed_files != ''
-      uses: iarekylew00t/verified-bot-commit@v1
+      uses: iarekylew00t/verified-bot-commit@v2
       with:
         message: ${{ inputs.release_tag }}
         files: ${{ steps.edit-version.outputs.changed_files }}

--- a/.github/actions/test-redis-package/action.yml
+++ b/.github/actions/test-redis-package/action.yml
@@ -20,7 +20,7 @@ runs:
     shell: bash
     run: echo "ARTIFACT_NAME=redis-oss-${{ inputs.redis_version }}-$(uname -m).zip" >> "$GITHUB_ENV"
   - name: Get binary packages
-    uses: actions/download-artifact@v4
+    uses: actions/download-artifact@v7
     with:
       name: ${{ env.ARTIFACT_NAME }}
   - name: Set up Homebrew

--- a/.github/actions/upload-packages/action.yml
+++ b/.github/actions/upload-packages/action.yml
@@ -60,13 +60,13 @@ runs:
       echo "Will download artifacts from workflow wth Run ID: ${{ inputs.run_id }}"
 
   - name: Configure aws credentials
-    uses: aws-actions/configure-aws-credentials@v4.3.1
+    uses: aws-actions/configure-aws-credentials@v6
     with:
       role-to-assume: ${{ inputs.BREW_S3_IAM_ARN }}
       aws-region: ${{ inputs.BREW_S3_REGION }}
 
   - name: Get binary packages
-    uses: actions/download-artifact@v4
+    uses: actions/download-artifact@v7
     with:
       run-id: ${{ inputs.run_id }}
       github-token: ${{ inputs.gh_token }}
@@ -125,7 +125,7 @@ runs:
 
   - name: Create verified commit
     if: ${{ env.changed_files }} != ''
-    uses: iarekylew00t/verified-bot-commit@v1
+    uses: iarekylew00t/verified-bot-commit@v2
     with:
       message: ${{ inputs.release_tag }}
       files: ${{ env.changed_files }}

--- a/.github/workflows/build-n-test.yml
+++ b/.github/workflows/build-n-test.yml
@@ -22,7 +22,7 @@ jobs:
       redis_version: ${{ steps.set_version.outputs.redis_version }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ inputs.release_tag == 'unstable' && 'unstable' || '' }}
     - name: Ensure Release Branch
@@ -66,7 +66,7 @@ jobs:
     runs-on: ${{ matrix.os_version }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ inputs.release_tag == 'unstable' && 'unstable' || '' }}
     - uses: ./.github/actions/test-redis-package

--- a/.github/workflows/release_build_and_test.yml
+++ b/.github/workflows/release_build_and_test.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ["ubuntu-latest"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate Redis Release Archive
         uses: redis-developer/redis-oss-release-automation/.github/actions/validate-redis-release-archive@main
@@ -73,7 +73,7 @@ jobs:
           RELEASE_HANDLE
 
       - name: Upload release handle artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release_handle
           path: result.json
@@ -87,7 +87,7 @@ jobs:
     if: failure()
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Detect env name
         id: detect-env

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate inputs
         id: validate-inputs
@@ -114,7 +114,7 @@ jobs:
           RESULT
 
       - name: Upload publish result artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release_info
           path: result.json


### PR DESCRIPTION
## Summary
RED-198334. Bump GitHub Actions still running on Node 20 ahead of the June 16, 2026 deprecation deadline.

- Bump `actions/checkout@v4` -> `@v6` (5 sites across `edit-version-file` composite + `build-n-test.yml` + `release_build_and_test.yml` + `release_publish.yml`)
- Bump `actions/upload-artifact@v4` -> `@v7` (3 sites) and `actions/download-artifact@v4` -> `@v7` (2 sites)
- Bump `aws-actions/configure-aws-credentials@v4.3.1` -> `@v6` in `upload-packages` composite action
- Bump `iarekylew00t/verified-bot-commit@v1` -> `@v2` (2 sites)

## Test plan
- [ ] `build-n-test.yml` builds + tests macOS binaries cleanly
- [ ] `release_build_and_test.yml` workflow_dispatch run with `edit-version-file` produces a verified bot commit on the release branch
- [ ] `release_publish.yml` workflow_dispatch run uploads packages and creates a verified tag
- [ ] OIDC credentials still work with `aws-actions/configure-aws-credentials@v6`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release-critical paths (artifact handoff, OIDC to S3, verified commits) but changes are dependency version bumps only; regressions would show up as workflow failures rather than silent app bugs.
> 
> **Overview**
> Bumps GitHub Actions that still run on **Node 20** to newer major versions ahead of GitHub’s deprecation deadline (**RED-198334**). Only `uses:` version pins change in composite actions and release workflows; build/sign/notarize/S3 logic is untouched.
> 
> **`actions/checkout`** goes from **v4 → v6** in `build-n-test.yml`, `release_build_and_test.yml`, `release_publish.yml`, and the `edit-version-file` composite (including checkout of `redis-oss-release-automation`). **`actions/upload-artifact`** and **`actions/download-artifact`** move from **v4 → v7** for binary zips, release handles, and publish metadata. **`aws-actions/configure-aws-credentials`** is **v4.3.1 → v6** in `upload-packages` (OIDC role assumption unchanged). **`iarekylew00t/verified-bot-commit`** is **v1 → v2** where release branches get verified bot commits after version/cask edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92f6c08056185e9c7bb3502d29f0a45370d8378f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->