### PR TITLE
RED-198334 Bump GH Actions off Node 20 (unstable)

### DIFF
--- a/.github/workflows/build-binary-dists.yml
+++ b/.github/workflows/build-binary-dists.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.os_version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: >-
             ${{ (github.ref_name == 'unstable'
@@ -54,7 +54,7 @@ jobs:
           echo "UNSIGNED_REDIS_BINARY=unsigned-redis-oss-unstable-$(uname -m).zip" >> $GITHUB_OUTPUT
 
       - name: Upload Redis Binary Distribution
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           path: ./${{ steps.build.outputs.UNSIGNED_REDIS_BINARY }}
           name: ${{ steps.build.outputs.UNSIGNED_REDIS_BINARY }}
@@ -94,7 +94,7 @@ jobs:
 
       - name: Upload build failure logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-failure-${{ matrix.os_version }}-homebrew
           path: /tmp/build-logs/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,14 +17,14 @@ jobs:
     name: Test Redis
     runs-on: ${{ inputs.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Use unstable branch when called via workflow_call (from nightly scheduler)
           # Use current branch when triggered by PR (for testing)
           ref: ${{ github.event_name == 'workflow_call' && 'unstable' || github.ref }}
 
       - name: Download built package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ inputs.artifact_name }}
 
@@ -65,7 +65,7 @@ jobs:
 
       - name: Upload Redis logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: redis-logs-${{ inputs.runner }}
           path: /tmp/redis-logs/


### PR DESCRIPTION
## Summary
RED-198334 on `unstable`. Bump GitHub Actions still running on Node 20 ahead of the June 16, 2026 deprecation deadline. Companion PR on `main`: [#61](https://github.com/redis/homebrew-redis/pull/61). The `unstable` branch has substantially different workflow content from `main` (2 workflows here vs 5 workflows + 5 composite actions on main), so this is a separate PR rather than a CP.

- Bump `actions/checkout@v4` -> `@v6` (2 sites)
- Bump `actions/upload-artifact@v4` -> `@v7` (3 sites across `build-binary-dists.yml` and `test.yml`)
- Bump `actions/download-artifact@v4` -> `@v7` in `test.yml`

## Test plan
- [ ] `build-binary-dists.yml` (`workflow_call`'d by nightly schedule) builds macOS unstable packages cleanly
- [ ] `test.yml` runs cleanly with bumped artifact actions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only CI dependency bumps with no changes to Redis build, install, or test logic.
> 
> **Overview**
> Updates the **unstable** macOS build and test workflows so they run on GitHub Actions versions that no longer depend on Node 20, ahead of the June 2026 deprecation.
> 
> In `build-binary-dists.yml`, **checkout** moves from `@v4` to `@v6`, and both **upload-artifact** steps (binary zip and failure logs) move from `@v4` to `@v7`. In `test.yml`, **checkout** is `@v6`, **download-artifact** is `@v7`, and failure **upload-artifact** is `@v7`. Build scripts, matrix runners, and test steps are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 681c284171623f791e72ecb9112a596b68be32df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->