### PR TITLE
Update macOS dependency format for Redis Cask

### DIFF
--- a/Casks/redis.rb
+++ b/Casks/redis.rb
@@ -10,7 +10,7 @@ cask "redis" do
   desc "Redis is an in-memory database that persists on disk. The data model is key-value, but many different kind of values are supported: Strings, Lists, Sets, Sorted Sets, Hashes, Streams, HyperLogLogs, Bitmaps."
   homepage "https://redis.io/"
 
-  depends_on macos: ">= :sonoma"
+  depends_on macos: :sonoma
 
   depends_on formula: "openssl@3"
   depends_on formula: "libomp"


### PR DESCRIPTION
Calling string comparison format for 'depends_on macOS:' is deprecated. This fix is to comply with homebrew best practices.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line cask metadata change with equivalent Sonoma minimum; no install or runtime behavior change.
> 
> **Overview**
> Updates the **Redis** Homebrew cask to use the non-deprecated macOS dependency syntax: `depends_on macos: :sonoma` instead of `depends_on macos: ">= :sonoma"`.
> 
> The minimum macOS requirement (Sonoma) is unchanged; this is a format-only change to match current Homebrew cask conventions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caf4b4b2f8950f73f986e7e2a0cc3b8da3c9d279. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->