### PR TITLE
Add uv dependency for rediseach build

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -10,6 +10,7 @@ brew install llvm@18
 brew install gnu-sed
 brew install automake
 brew install libtool
+brew install uv
 
 # Ensure Homebrew's cmake does not interfere
 brew uninstall --ignore-dependencies cmake || true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line addition to a dev/CI setup script with no runtime, auth, or application code changes.
> 
> **Overview**
> Adds **`brew install uv`** to the macOS Homebrew dependency bootstrap in `scripts/install_deps.sh`, alongside existing tools like `libtool` and `automake`.
> 
> This ensures environments that run this script have **uv** available for the RediSearch build pipeline (per the PR intent), without changing any other install steps or CMake/Rust logic in the script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c7481fd426c3097cb45951ee5ce45dd1f351225. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->