### PR TITLE
Revert "Add uv dependency for rediseach build"

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -10,7 +10,6 @@ brew install llvm@18
 brew install gnu-sed
 brew install automake
 brew install libtool
-brew install uv
 
 # Ensure Homebrew's cmake does not interfere
 brew uninstall --ignore-dependencies cmake || true


### PR DESCRIPTION
Reverts redis/homebrew-redis#66

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line removal from a dev setup script; no runtime or security impact.
> 
> **Overview**
> Reverts redis/homebrew-redis#66 by dropping **`uv`** from the Homebrew install list in **`scripts/install_deps.sh`**.
> 
> The rest of the script (coreutils, llvm, pinned CMake, Rust, etc.) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a519c79c2a860582bc1ab12aaa06893f82149cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->