### PR TITLE
Unstable migrate to redis modules.yaml workflow

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,10 +3,7 @@
 set -e
 
 export HOMEBREW_PREFIX="$(brew --prefix)"
-export BUILD_WITH_MODULES=yes
-export MODULE_VERSION=master
 export BUILD_TLS=yes
-export DISABLE_WERRORS=yes
 # Override RediSearch's new LTO=1 default; toolchain support TBD.
 export LTO=0
 PATH="$HOMEBREW_PREFIX/opt/llvm@18/bin:$HOMEBREW_PREFIX/opt/make/libexec/gnubin:$HOMEBREW_PREFIX/opt/gnu-sed/libexec/gnubin:$HOMEBREW_PREFIX/opt/coreutils/libexec/gnubin:$PATH" # Override macOS defaults.
@@ -16,17 +13,14 @@ export CPPFLAGS="-I$HOMEBREW_PREFIX/opt/llvm@18/include"
 curl -L "https://github.com/redis/redis/archive/refs/heads/unstable.tar.gz" -o redis-unstable.tar.gz
 tar xzf redis-unstable.tar.gz
 
-# Update module versions to use master branch
-for module in redisbloom redisearch redistimeseries redisjson; do
-  if [ -f "redis-unstable/modules/${module}/Makefile" ]; then
-    sed -i 's/MODULE_VERSION = .*/MODULE_VERSION = master/' "redis-unstable/modules/${module}/Makefile"
-    echo "Updated MODULE_VERSION to master for ${module}"
-  fi
-done
+# Point every module at the master branch in the manifest.
+yq -i '.modules[].ref = "master"' redis-unstable/modules/modules.yaml
+
+# Clone the bundled modules (shallow) at the master refs set above.
+make -C redis-unstable modules-update MODULES_UPDATE_SHALLOW=1
 
 mkdir -p build_dir/etc
-make -C redis-unstable -j "$(nproc)" all OS=macos
-make -C redis-unstable install PREFIX=$(pwd)/build_dir OS=macos
+make -C redis-unstable -j "$(nproc)" deploy PREFIX=$(pwd)/build_dir
 cp ./configs/redis.conf build_dir/etc/redis.conf
 
 # Verify that all required modules were built and installed

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -10,6 +10,7 @@ brew install llvm@18
 brew install gnu-sed
 brew install automake
 brew install libtool
+brew install yq
 
 # Ensure Homebrew's cmake does not interfere
 brew uninstall --ignore-dependencies cmake || true


### PR DESCRIPTION
Adopt the modules-modernization workflow from redis 4dd58ca: the per-module stub Makefiles and BUILD_WITH_MODULES/DISABLE_WERRORS knobs are gone upstream, replaced by a manifest-driven build.

- Drop BUILD_WITH_MODULES, DISABLE_WERRORS, and the sed loop over the removed modules/<name>/Makefile stubs.
- Set every module ref to master via yq on modules.yaml, then shallow clone with modules-update.
- Replace make all + make install with a single make deploy.
- Install yq in install_deps.sh so the manifest edit runs in CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Redis and bundled modules are fetched and built in CI; failures could surface as missing `.so` files until the new workflow is stable, but scope is limited to build scripts.
> 
> **Overview**
> **Build pipeline** now follows upstream Redis’s manifest-driven module flow instead of per-module stub Makefiles and legacy env knobs.
> 
> `build.sh` drops `BUILD_WITH_MODULES`, `MODULE_VERSION`, and `DISABLE_WERRORS`, removes the `sed` loop over `modules/<name>/Makefile`, and instead sets every module ref to `master` in `modules.yaml` with **yq**, runs **`make modules-update`** (shallow), then **`make deploy`** into `build_dir` instead of separate **`make all`** + **`make install`** with `OS=macos`.
> 
> `install_deps.sh` adds **Homebrew `yq`** so CI can edit the manifest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44e4e6ceb8ef13d2edad0a6d21d9c4f7fa6e64e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->