### PR TITLE
Merge new modules build from unstable

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,9 +3,6 @@
 set -e
 
 export HOMEBREW_PREFIX="$(brew --prefix)"
-export BUILD_WITH_MODULES=yes
-export BUILD_TLS=yes
-export DISABLE_WERRORS=yes
 # Override RediSearch's new LTO=1 default; toolchain support TBD.
 export LTO=0
 PATH="$HOMEBREW_PREFIX/opt/llvm@18/bin:$HOMEBREW_PREFIX/opt/make/libexec/gnubin:$HOMEBREW_PREFIX/opt/gnu-sed/libexec/gnubin:$HOMEBREW_PREFIX/opt/coreutils/libexec/gnubin:$PATH" # Override macOS defaults.
@@ -24,8 +21,7 @@ curl -L "https://github.com/redis/redis/archive/refs/tags/$REDIS_VERSION.tar.gz"
 tar xzf redis.tar.gz
 
 mkdir -p build_dir/etc
-make -C redis-$REDIS_VERSION -j "$(nproc)" all OS=macos
-make -C redis-$REDIS_VERSION install PREFIX=$(pwd)/build_dir OS=macos
+make -C redis-$REDIS_VERSION -j "$(nproc)" deploy PREFIX=$(pwd)/build_dir
 
 # Verify that all required modules were built and installed
 echo "Verifying Redis modules..."

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -10,6 +10,7 @@ brew install llvm@18
 brew install gnu-sed
 brew install automake
 brew install libtool
+brew install yq
 
 # Ensure Homebrew's cmake does not interfere
 brew uninstall --ignore-dependencies cmake || true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changing how Redis and bundled modules are built can break CI or produce missing `.so` files if upstream `deploy` differs from the old flags; the existing module check mitigates silent failures.
> 
> **Overview**
> **Build pipeline** switches to Redis upstream’s integrated module build: `scripts/build.sh` no longer sets `BUILD_WITH_MODULES`, `BUILD_TLS`, or `DISABLE_WERRORS`, and replaces separate `make all` / `make install` with `OS=macos` by a single **`make deploy PREFIX=...`** into `build_dir`. Module verification and zip packaging are unchanged.
> 
> **Dependencies:** `scripts/install_deps.sh` now installs **`yq`** via Homebrew, likely for parsing config in the new build flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73b3a5b67b790cd9a003476cc00aae9ba3e212e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->