### PR TITLE
Download the full archive

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -17,7 +17,7 @@ fi
 
 REDIS_VERSION="$1"
 
-curl -L "https://github.com/redis/redis/archive/refs/tags/$REDIS_VERSION.tar.gz" -o redis.tar.gz
+curl --fail -SsL -o redis.tar.gz "https://github.com/redis/redis/releases/download/$REDIS_VERSION/redis-full.tar.gz"
 tar xzf redis.tar.gz
 
 mkdir -p build_dir/etc


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Build-only change, but swapping archive type/URL can break the pipeline if the extracted directory name or tree no longer matches `redis-$REDIS_VERSION` and `make deploy`.
> 
> **Overview**
> The build script now downloads **`redis-full.tar.gz`** from GitHub **Releases** instead of the tag **source** archive (`archive/refs/tags/...tar.gz`), so the build is aligned with the “full” Redis release bundle (including what’s needed for the existing module verification step).
> 
> The **`curl`** invocation adds **`--fail`**, **`-SsL`**, and reorders flags so failed HTTP responses fail the script and redirects are followed reliably.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a780418f35a92db0384c6aba8243f91ff71a707. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->