### PR TITLE
Support internal releases and Homebrew 6.0 tap trust

### DIFF
--- a/.github/actions/test-redis-package/action.yml
+++ b/.github/actions/test-redis-package/action.yml
@@ -29,6 +29,8 @@ runs:
       export HOMEBREW_GITHUB_API_TOKEN=$GITHUB_TOKEN
       brew update
       brew tap ${{ inputs.tap }} .
+      # Homebrew 6.0.0+ refuses non-official taps unless trusted
+      brew trust ${{ inputs.tap }}
   - name: Edit cask file
     shell: bash
     run: |

--- a/Casks/redis-rc.rb
+++ b/Casks/redis-rc.rb
@@ -10,7 +10,7 @@ cask "redis-rc" do
   desc "THIS IS A PRE-RELEASE VERSION!! BREAKING CHANGES MAY OCCUR WITHOUT NOTICE!! Redis is an in-memory database that persists on disk. The data model is key-value, but many different kind of values are supported: Strings, Lists, Sets, Sorted Sets, Hashes, Streams, HyperLogLogs, Bitmaps."
   homepage "https://redis.io/"
 
-  depends_on macos: ">= :sonoma"
+  depends_on macos: :sonoma
 
   depends_on formula: "openssl@3"
   depends_on formula: "libomp"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ To install the latest version of Redis Open Source using Homebrew Cask, please u
 
 ```bash
 brew tap redis/redis
+# brew trust is required on Homebrew 6.0+
+brew trust redis/redis
 brew install --cask redis
 ```
 
@@ -11,6 +13,8 @@ For pre-release versions, you can use the following command. Note that this will
 
 ```bash
 brew tap redis/redis
+# brew trust is required on Homebrew 6.0+
+brew trust redis/redis
 brew install --cask redis-rc
 ```
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -17,8 +17,14 @@ fi
 
 REDIS_VERSION="$1"
 
-curl --fail -SsL -o redis.tar.gz "https://github.com/redis/redis/releases/download/$REDIS_VERSION/redis-full.tar.gz"
-tar xzf redis.tar.gz
+# Internal releases lack the redis-full archive, fall back to the tag source.
+if curl --fail -SsL -o redis.tar.gz "https://github.com/redis/redis/releases/download/$REDIS_VERSION/redis-full.tar.gz"; then
+  tar xzf redis.tar.gz
+else
+  curl --fail -SsL -o redis.tar.gz "https://github.com/redis/redis/archive/refs/tags/$REDIS_VERSION.tar.gz"
+  tar xzf redis.tar.gz
+  make -C redis-$REDIS_VERSION modules-update MODULES_UPDATE_SHALLOW=1
+fi
 
 mkdir -p build_dir/etc
 make -C redis-$REDIS_VERSION -j "$(nproc)" deploy PREFIX=$(pwd)/build_dir


### PR DESCRIPTION
- build.sh: fall back to the tag source archive + modules-update when the redis-full asset is absent (internal releases are just a tag)
- test action: brew trust the tap so Homebrew 6.0+ will load the cask
- README: document the required brew trust step for Homebrew 6.0+
- redis-rc cask: use the non-deprecated depends_on macos: :sonoma form

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging, CI, and documentation changes only; no runtime Redis or security logic is modified.
> 
> **Overview**
> **Build pipeline** can produce macOS packages for **internal Redis tags** that do not ship a `redis-full` release asset: `scripts/build.sh` tries `redis-full.tar.gz` first, then falls back to the tag source archive and runs `modules-update` before `deploy`.
> 
> **Homebrew 6.0+** requires trusting third-party taps before casks load. CI’s test action runs `brew trust` after tapping, and the **README** documents the same `brew trust redis/redis` step for stable and RC installs.
> 
> The **redis-rc** cask updates `depends_on macos` from the deprecated `">= :sonoma"` form to `:sonoma`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5785855aabbeb3bc487ae71920f18381b36ec7a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->