### PR TITLE
Support old module build system

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,6 +3,7 @@
 set -e
 
 export HOMEBREW_PREFIX="$(brew --prefix)"
+export BUILD_TLS=yes
 # Override RediSearch's new LTO=1 default; toolchain support TBD.
 export LTO=0
 PATH="$HOMEBREW_PREFIX/opt/llvm@18/bin:$HOMEBREW_PREFIX/opt/make/libexec/gnubin:$HOMEBREW_PREFIX/opt/gnu-sed/libexec/gnubin:$HOMEBREW_PREFIX/opt/coreutils/libexec/gnubin:$PATH" # Override macOS defaults.
@@ -27,7 +28,12 @@ else
 fi
 
 mkdir -p build_dir/etc
-make -C redis-$REDIS_VERSION -j "$(nproc)" deploy PREFIX=$(pwd)/build_dir
+if [ -f "redis-$REDIS_VERSION/modules/modules.yaml" ]; then
+  make -C redis-$REDIS_VERSION -j "$(nproc)" deploy PREFIX=$(pwd)/build_dir
+else
+  export BUILD_WITH_MODULES=yes
+  make -C redis-$REDIS_VERSION -j "$(nproc)" all OS=macos
+fi
 
 # Verify that all required modules were built and installed
 echo "Verifying Redis modules..."

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -33,6 +33,7 @@ if [ -f "redis-$REDIS_VERSION/modules/modules.yaml" ]; then
 else
   export BUILD_WITH_MODULES=yes
   make -C redis-$REDIS_VERSION -j "$(nproc)" all OS=macos
+  make -C redis-$REDIS_VERSION install PREFIX=$(pwd)/build_dir OS=macos
 fi
 
 # Verify that all required modules were built and installed


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes only affect local/CI packaging in scripts/build.sh with no runtime app or auth impact; legacy path is macOS-specific.
> 
> **Overview**
> **`scripts/build.sh`** now handles Redis trees that still use the pre-`modules.yaml` module layout instead of always running `make deploy`.
> 
> When `redis-$REDIS_VERSION/modules/modules.yaml` is present, behavior is unchanged: parallel **`deploy`** into `build_dir`. Otherwise the script sets **`BUILD_WITH_MODULES=yes`**, runs **`make all`** and **`make install`** with **`OS=macos`**, and still relies on the existing module verification step.
> 
> **`BUILD_TLS=yes`** is exported for all builds so TLS-enabled Redis is built consistently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2cd35b514c16d7d16a39d36ca586ad973c0d372. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->