### PR TITLE
Fix: run modules-update only for new releases

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -24,7 +24,9 @@ if curl --fail -SsL -o redis.tar.gz "https://github.com/redis/redis/releases/dow
 else
   curl --fail -SsL -o redis.tar.gz "https://github.com/redis/redis/archive/refs/tags/$REDIS_VERSION.tar.gz"
   tar xzf redis.tar.gz
-  make -C redis-$REDIS_VERSION modules-update MODULES_UPDATE_SHALLOW=1
+  if [ -f "redis-$REDIS_VERSION/modules/modules.yaml" ]; then
+    make -C redis-$REDIS_VERSION modules-update MODULES_UPDATE_SHALLOW=1
+  fi
 fi
 
 mkdir -p build_dir/etc


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Build-script conditional only; no runtime Redis, auth, or data-path changes.
> 
> **Overview**
> When `redis-full.tar.gz` is unavailable and the build falls back to the GitHub tag archive, **`modules-update` is no longer always invoked** after extract.
> 
> It now runs only if `redis-$REDIS_VERSION/modules/modules.yaml` exists—the same signal the script already uses to choose the `deploy` vs legacy macOS module build path. **Older or internal tags without the modules manifest skip `modules-update`**, which aligns with the PR title’s intent for non–“new release” sources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6929662857177338475c11f6afcec0b248e6a6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->