### PR TITLE
Fix sha256 substitution

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,11 +41,15 @@ jobs:
 
           ARTIFACT_FILE=$(ls unsigned-redis-oss-unstable-*.zip)
           ARTIFACT_PATH="$(pwd)/$ARTIFACT_FILE"
+          ARTIFACT_SHA=$(shasum -a 256 "$ARTIFACT_PATH" | awk '{print $1}')
           TAP_PATH=$(brew --repository redis/redis-unstable)
           CASK_FILE="$TAP_PATH/Casks/redis.rb"
+          echo "Computed sha256 for $ARTIFACT_FILE: $ARTIFACT_SHA"
 
           sed -i "" "s|url \".*\"|url \"file://$ARTIFACT_PATH\"|" "$CASK_FILE"
-          sed -i "" '/sha256 arm:/,/intel:/d' "$CASK_FILE"
+
+          if [ "$(uname -m)" = "arm64" ]; then SHA_KEY=arm; else SHA_KEY=intel; fi
+          sed -i "" "/sha256 arm:/,/intel:/ s/$SHA_KEY: \"[^\"]*\"/$SHA_KEY: \"$ARTIFACT_SHA\"/" "$CASK_FILE"
 
       - name: Install Redis via cask
         run: |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only changes the GitHub Actions test workflow for local cask installs; no runtime Redis or packaging logic.
> 
> **Overview**
> **Fixes Homebrew cask install in the unstable package test workflow** by keeping the cask’s `sha256` block and updating it to match the downloaded unsigned zip instead of removing checksums entirely.
> 
> During **Setup local tap**, the workflow now computes `ARTIFACT_SHA` with `shasum -a 256`, logs it, and after rewriting the cask `url` to `file://…`, selects **arm** vs **intel** from `uname -m` and runs a targeted `sed` to replace only that architecture’s hash in `Casks/redis.rb`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e89b5d73b0736899b87110647840046c3f1db9b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->