### PR TITLE
Fix tap trust order in Test Redis action

### DIFF
--- a/.github/actions/test-redis-package/action.yml
+++ b/.github/actions/test-redis-package/action.yml
@@ -27,10 +27,14 @@ runs:
     shell: bash
     run: |
       export HOMEBREW_GITHUB_API_TOKEN=$GITHUB_TOKEN
+      # Homebrew 6.0.0+ requires non-official taps to be trusted before their casks
+      # load. `brew trust` can't reliably trust a tap cloned from a local path like
+      # this one (its remote isn't a stable reference), so skip the check instead.
+      # Persist via GITHUB_ENV since later steps (e.g. Install Redis) run in a new shell.
+      echo "HOMEBREW_NO_REQUIRE_TAP_TRUST=1" >> "$GITHUB_ENV"
+      export HOMEBREW_NO_REQUIRE_TAP_TRUST=1
       brew update
       brew tap ${{ inputs.tap }} .
-      # Homebrew 6.0.0+ refuses non-official taps unless trusted
-      brew trust ${{ inputs.tap }}
   - name: Edit cask file
     shell: bash
     run: |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only Homebrew setup change with no impact on runtime Redis packaging or application code.
> 
> **Overview**
> Updates the **Test Redis package** composite action for **Homebrew 6.0+**, which blocks loading casks from untrusted non-official taps.
> 
> Instead of running `brew trust` on the input tap (which fails for taps added via `brew tap … .` because the remote isn’t a stable reference), the **Set up Homebrew** step sets **`HOMEBREW_NO_REQUIRE_TAP_TRUST=1`** in **`GITHUB_ENV`** and in the current shell so later steps like **Install Redis** still skip the trust check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef56705c8986200dcd5a44ec5d2d4268091d4427. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->