### PR TITLE
Fix tap trust order in Test Redis action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,9 +35,10 @@ jobs:
 
       - name: Setup local tap
         run: |
+          # brew trust can't trust a tap cloned from a local path, so skip the check
+          echo "HOMEBREW_NO_REQUIRE_TAP_TRUST=1" >> "$GITHUB_ENV"
+          export HOMEBREW_NO_REQUIRE_TAP_TRUST=1
           brew tap redis/redis-unstable .
-          # Homebrew 6.0.0+ refuses non-official taps unless trusted
-          brew trust redis/redis-unstable
 
           ARTIFACT_FILE=$(ls unsigned-redis-oss-unstable-*.zip)
           ARTIFACT_PATH="$(pwd)/$ARTIFACT_FILE"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only workflow change with no application or security logic impact.
> 
> **Overview**
> **Fixes CI local tap setup** for the Redis unstable package test workflow on Homebrew 6+.
> 
> Instead of running `brew trust redis/redis-unstable` (which does not work when the tap is added from a local path via `brew tap redis/redis-unstable .`), the **Setup local tap** step now sets `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` in `GITHUB_ENV` and exports it before `brew tap`, so the job can install from the locally patched cask without a trust step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 820a792902c0fc6b3e5bcd7048dc6a769912ecb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->